### PR TITLE
Decode multi-byte characters split across frames correctly

### DIFF
--- a/frontend/src/frame.ts
+++ b/frontend/src/frame.ts
@@ -1,7 +1,7 @@
 export interface DataFrame {
     type: FrameType.Data;
     size: number;
-    data: string;
+    data: Buffer;
 }
 
 export interface SizeFrame {
@@ -49,7 +49,7 @@ export function decode(buf: Buffer): Frame | null {
             return {
                 type: FrameType.Data,
                 size: size + 4,
-                data: buf.slice(5, 5 + size - 1).toString('utf8')
+                data: buf.slice(5, 5 + size - 1)
             };
         case FrameType.Size:
             return {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -2,6 +2,7 @@ import * as net from 'net';
 import * as path from 'path';
 import * as child_process from 'child_process';
 import { EventEmitter } from 'events';
+import { StringDecoder } from 'string_decoder';
 import * as getPort from 'get-port';
 
 import * as frame from './frame';
@@ -132,6 +133,7 @@ class Pty extends EventEmitter implements IPty {
             // Don't batch up tcp writes
             this._socket.setNoDelay(true);
 
+            const decoder = new StringDecoder('utf8');
             this._socket.on('data', data => {
                 // TODO: this results in more data copies than needed
                 let buf = this._pendingBuffer
@@ -144,7 +146,7 @@ class Pty extends EventEmitter implements IPty {
                     if (f) {
                         switch (f.type) {
                             case frame.FrameType.Data:
-                                this.emit('data', f.data);
+                                this.emit('data', decoder.write(f.data));
                                 break;
                             case frame.FrameType.Size:
                                 // The backend can't send size frames


### PR DESCRIPTION
As bytes get streamed from the backend to the frontend, multi-byte characters can sometimes get split across multiple frames. In this situation, it is not sufficient to convert the buffer directly to a utf8 string because the incomplete character is translated into unrecognizable characters.

This PR changes the decoder to use the built-in NodeJS `StringDecoder` class, which is able to handle these incomplete characters split across separate data chunks and still output the right string.